### PR TITLE
Fallback value for work.end

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -123,7 +123,7 @@ export default function Page() {
                       </span>
                     </h3>
                     <div className="text-sm tabular-nums text-gray-500">
-                      {work.start} - {work.end}
+                      {work.start} - {work.end ?? "Present"}
                     </div>
                   </div>
 


### PR DESCRIPTION
Provided a way to easily list current jobs by not setting a `end` value in the data file.

