### PR TITLE
Highlight the Skill section under hard copy

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -162,7 +162,14 @@ export default function Page() {
           <h2 className="text-xl font-bold">Skills</h2>
           <div className="flex flex-wrap gap-1">
             {RESUME_DATA.skills.map((skill) => {
-              return <Badge key={skill}>{skill}</Badge>;
+              return (
+                <Badge
+                  key={skill}
+                  className=" print:text-primary print:underline"
+                >
+                  {skill}
+                </Badge>
+              );
             })}
           </div>
         </Section>

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -9,7 +9,7 @@ const badgeVariants = cva(
     variants: {
       variant: {
         default:
-          "border-transparent bg-primary/80 text-primary-foreground hover:bg-primary/60",
+          "border-transparent bg-primary/80 text-primary-foreground hover:bg-primary/60 print:text-primary print:underline",
         secondary:
           "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/60",
         destructive:

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -9,7 +9,7 @@ const badgeVariants = cva(
     variants: {
       variant: {
         default:
-          "border-transparent bg-primary/80 text-primary-foreground hover:bg-primary/60 print:text-primary print:underline",
+          "border-transparent bg-primary/80 text-primary-foreground hover:bg-primary/60",
         secondary:
           "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/60",
         destructive:


### PR DESCRIPTION
The Skill section Badge looks good on device but the colour is pale if download as a file or print it out.
<img width="667" alt="Screenshot 2023-12-29 at 18 47 13" src="https://github.com/BartoszJarocki/cv/assets/100838867/21cf6a0f-dcb2-4885-8133-b4eb1e1a7445">
Add some print styles to highlight the Skill section under hard copy.
<img width="612" alt="Screenshot 2023-12-29 at 18 47 43" src="https://github.com/BartoszJarocki/cv/assets/100838867/45bc4e55-839a-480a-89dd-1162146e35ae">
