### PR TITLE
feat: add types, allow bullets for description

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Card, CardHeader, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -68,7 +69,10 @@ export default function Page() {
                   asChild
                 >
                   <a href={social.url}>
-                    <social.icon className="h-4 w-4" />
+                    {React.createElement(
+                      social.icon as React.ComponentType<{ className: string }>,
+                      { className: "h-4 w-4" },
+                    )}
                   </a>
                 </Button>
               ))}
@@ -132,7 +136,20 @@ export default function Page() {
                   </h4>
                 </CardHeader>
                 <CardContent className="mt-2 text-xs">
-                  {work.description}
+                  {typeof work.description === "string" ? (
+                    <p>{work.description}</p>
+                  ) : (
+                    work.description?.map((desc) => {
+                      return (
+                        <p key={desc} className="mb-1">
+                          <span className="mr-2">
+                            {work?.customBullet || "•"}
+                          </span>
+                          {desc}
+                        </p>
+                      );
+                    })
+                  )}
                 </CardContent>
               </Card>
             );
@@ -177,7 +194,7 @@ export default function Page() {
                   title={project.title}
                   description={project.description}
                   tags={project.techStack}
-                  link={"link" in project ? project.link.href : undefined}
+                  link={"link" in project ? project.link?.href : undefined}
                 />
               );
             })}

--- a/src/data/resume-data.tsx
+++ b/src/data/resume-data.tsx
@@ -18,8 +18,9 @@ import {
   YearProgressLogo,
 } from "@/images/logos";
 import { GitHubIcon, LinkedInIcon, XIcon } from "@/components/icons";
+import { ResumeData } from "./resume-data.types";
 
-export const RESUME_DATA = {
+export const RESUME_DATA: ResumeData = {
   name: "Bartosz Jarocki",
   initials: "BJ",
   location: "Wrocław, Poland, CET",

--- a/src/data/resume-data.types.ts
+++ b/src/data/resume-data.types.ts
@@ -1,0 +1,64 @@
+import { StaticImageData } from "next/image";
+export type ResumeData = {
+  name: string;
+  initials: string;
+  location: string;
+  locationLink: string;
+  about: string;
+  summary: string;
+  avatarUrl: string;
+  personalWebsiteUrl: string;
+  contact: {
+    email: string;
+    tel: string;
+    social: {
+      name: string;
+      url: string;
+      icon: React.ComponentType;
+    }[];
+  };
+  education: {
+    school: string;
+    degree: string;
+    grade?: string;
+    start: string;
+    end: string;
+  }[];
+  work: {
+    company: string;
+    link: string;
+    badges: string[];
+    title: string;
+    logo: React.ComponentType<{}> | StaticImageData;
+    start: string;
+    end: string;
+    description: string | string[];
+    customBullet?: string;
+  }[];
+  skills: string[];
+  projects: {
+    title: string;
+    techStack: string[];
+    description: string;
+    logo: React.ComponentType<{}> | StaticImageData;
+    link?: {
+      label: string;
+      href: string;
+    };
+  }[];
+  certification?: {
+    name: string;
+    providerName: string;
+    link: string;
+    issueDate: string;
+    expirationDate: string;
+    certificateId: string;
+  }[];
+  publication?: {
+    name: string;
+    providerName: string;
+    link: string;
+    issueDate: string;
+    description: string;
+  }[];
+};


### PR DESCRIPTION
Add and fix some types, 

Closes #23 

Allows use of string or an array of string for desc, using an array creates bullet points. the bullets can be customized.

### This is what the config would look like: 
<img width="419" alt="image" src="https://github.com/BartoszJarocki/cv/assets/87754854/dc7bded1-91e4-4e5b-8dc3-1cd06a807e59">

## Preview: 

### When no `customBullet` is provided
![image](https://github.com/BartoszJarocki/cv/assets/87754854/f5320afa-6c8f-4659-abb7-4e5a84dcd02e)

### When `customBullet` is provided
![image](https://github.com/BartoszJarocki/cv/assets/87754854/d3e0daea-b952-41de-a1d6-0c842d510e7f)