### PR TITLE
Move homepage sections into individual components

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,12 @@
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { Card, CardHeader, CardContent } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 import { CommandMenu } from "@/components/command-menu";
 import { Metadata } from "next";
-import { Section } from "@/components/ui/section";
-import { GlobeIcon, MailIcon, PhoneIcon } from "lucide-react";
-import { Button } from "@/components/ui/button";
 import { RESUME_DATA } from "@/data/resume-data";
-import { ProjectCard } from "@/components/project-card";
+import { Personal } from "@/components/sections/Personal";
+import { Summary } from "@/components/sections/Summary";
+import { WorkExperience } from "@/components/sections/WorkExperience";
+import { Education } from "@/components/sections/Education";
+import { Skills } from "@/components/sections/Skills";
+import { Projects } from "@/components/sections/Projects";
 
 export const metadata: Metadata = {
   title: `${RESUME_DATA.name} | ${RESUME_DATA.about}`,
@@ -18,171 +17,12 @@ export default function Page() {
   return (
     <main className="container relative mx-auto scroll-my-12 overflow-auto p-4 print:p-12 md:p-16">
       <section className="mx-auto w-full max-w-2xl space-y-8 bg-white print:space-y-6">
-        <div className="flex items-center justify-between">
-          <div className="flex-1 space-y-1.5">
-            <h1 className="text-2xl font-bold">{RESUME_DATA.name}</h1>
-            <p className="max-w-md text-pretty font-mono text-sm text-muted-foreground">
-              {RESUME_DATA.about}
-            </p>
-            <p className="max-w-md items-center text-pretty font-mono text-xs text-muted-foreground">
-              <a
-                className="inline-flex gap-x-1.5 align-baseline leading-none hover:underline"
-                href={RESUME_DATA.locationLink}
-                target="_blank"
-              >
-                <GlobeIcon className="h-3 w-3" />
-                {RESUME_DATA.location}
-              </a>
-            </p>
-            <div className="flex gap-x-1 pt-1 font-mono text-sm text-muted-foreground print:hidden">
-              {RESUME_DATA.contact.email ? (
-                <Button
-                  className="h-8 w-8"
-                  variant="outline"
-                  size="icon"
-                  asChild
-                >
-                  <a href={`mailto:${RESUME_DATA.contact.email}`}>
-                    <MailIcon className="h-4 w-4" />
-                  </a>
-                </Button>
-              ) : null}
-              {RESUME_DATA.contact.tel ? (
-                <Button
-                  className="h-8 w-8"
-                  variant="outline"
-                  size="icon"
-                  asChild
-                >
-                  <a href={`tel:${RESUME_DATA.contact.tel}`}>
-                    <PhoneIcon className="h-4 w-4" />
-                  </a>
-                </Button>
-              ) : null}
-              {RESUME_DATA.contact.social.map((social) => (
-                <Button
-                  key={social.name}
-                  className="h-8 w-8"
-                  variant="outline"
-                  size="icon"
-                  asChild
-                >
-                  <a href={social.url}>
-                    <social.icon className="h-4 w-4" />
-                  </a>
-                </Button>
-              ))}
-            </div>
-            <div className="hidden flex-col gap-x-1 font-mono text-sm text-muted-foreground print:flex">
-              {RESUME_DATA.contact.email ? (
-                <a href={`mailto:${RESUME_DATA.contact.email}`}>
-                  <span className="underline">{RESUME_DATA.contact.email}</span>
-                </a>
-              ) : null}
-              {RESUME_DATA.contact.tel ? (
-                <a href={`tel:${RESUME_DATA.contact.tel}`}>
-                  <span className="underline">{RESUME_DATA.contact.tel}</span>
-                </a>
-              ) : null}
-            </div>
-          </div>
-
-          <Avatar className="h-28 w-28">
-            <AvatarImage alt={RESUME_DATA.name} src={RESUME_DATA.avatarUrl} />
-            <AvatarFallback>{RESUME_DATA.initials}</AvatarFallback>
-          </Avatar>
-        </div>
-        <Section>
-          <h2 className="text-xl font-bold">About</h2>
-          <p className="text-pretty font-mono text-sm text-muted-foreground">
-            {RESUME_DATA.summary}
-          </p>
-        </Section>
-        <Section>
-          <h2 className="text-xl font-bold">Work Experience</h2>
-          {RESUME_DATA.work.map((work) => {
-            return (
-              <Card key={work.company}>
-                <CardHeader>
-                  <div className="flex items-center justify-between gap-x-2 text-base">
-                    <h3 className="inline-flex items-center justify-center gap-x-1 font-semibold leading-none">
-                      <a className="hover:underline" href={work.link}>
-                        {work.company}
-                      </a>
-
-                      <span className="inline-flex gap-x-1">
-                        {work.badges.map((badge) => (
-                          <Badge
-                            variant="secondary"
-                            className="align-middle text-xs"
-                            key={badge}
-                          >
-                            {badge}
-                          </Badge>
-                        ))}
-                      </span>
-                    </h3>
-                    <div className="text-sm tabular-nums text-gray-500">
-                      {work.start} - {work.end}
-                    </div>
-                  </div>
-
-                  <h4 className="font-mono text-sm leading-none">
-                    {work.title}
-                  </h4>
-                </CardHeader>
-                <CardContent className="mt-2 text-xs">
-                  {work.description}
-                </CardContent>
-              </Card>
-            );
-          })}
-        </Section>
-        <Section>
-          <h2 className="text-xl font-bold">Education</h2>
-          {RESUME_DATA.education.map((education) => {
-            return (
-              <Card key={education.school}>
-                <CardHeader>
-                  <div className="flex items-center justify-between gap-x-2 text-base">
-                    <h3 className="font-semibold leading-none">
-                      {education.school}
-                    </h3>
-                    <div className="text-sm tabular-nums text-gray-500">
-                      {education.start} - {education.end}
-                    </div>
-                  </div>
-                </CardHeader>
-                <CardContent className="mt-2">{education.degree}</CardContent>
-              </Card>
-            );
-          })}
-        </Section>
-        <Section>
-          <h2 className="text-xl font-bold">Skills</h2>
-          <div className="flex flex-wrap gap-1">
-            {RESUME_DATA.skills.map((skill) => {
-              return <Badge key={skill}>{skill}</Badge>;
-            })}
-          </div>
-        </Section>
-
-        <Section className="print-force-new-page scroll-mb-16">
-          <h2 className="text-xl font-bold">Projects</h2>
-          <div className="-mx-3 grid grid-cols-1 gap-3 print:grid-cols-3 print:gap-2 md:grid-cols-2 lg:grid-cols-3">
-            {RESUME_DATA.projects.map((project) => {
-              return (
-                <ProjectCard
-                  key={project.title}
-                  title={project.title}
-                  description={project.description}
-                  tags={project.techStack}
-                  link={"link" in project ? project.link.href : undefined}
-                />
-              );
-            })}
-          </div>
-        </Section>
+        <Personal />
+        <Summary />
+        <WorkExperience />
+        <Education />
+        <Skills />
+        <Projects />
       </section>
 
       <CommandMenu

--- a/src/components/sections/Education.tsx
+++ b/src/components/sections/Education.tsx
@@ -1,0 +1,28 @@
+import { RESUME_DATA } from "@/data/resume-data";
+import { Section } from "../ui/section";
+import { Card, CardContent, CardHeader } from "../ui/card";
+
+export const Education = () => {
+  return (
+    <Section>
+      <h2 className="text-xl font-bold">Education</h2>
+      {RESUME_DATA.education.map((education) => {
+        return (
+          <Card key={education.school}>
+            <CardHeader>
+              <div className="flex items-center justify-between gap-x-2 text-base">
+                <h3 className="font-semibold leading-none">
+                  {education.school}
+                </h3>
+                <div className="text-sm tabular-nums text-gray-500">
+                  {education.start} - {education.end}
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent className="mt-2">{education.degree}</CardContent>
+          </Card>
+        );
+      })}
+    </Section>
+  );
+};

--- a/src/components/sections/Personal.tsx
+++ b/src/components/sections/Personal.tsx
@@ -1,0 +1,73 @@
+import { RESUME_DATA } from "@/data/resume-data";
+import { Avatar, AvatarFallback, AvatarImage } from "../ui/avatar";
+import { GlobeIcon, MailIcon, PhoneIcon } from "lucide-react";
+import { Button } from "../ui/button";
+
+export const Personal = () => {
+  return (
+    <div className="flex items-center justify-between">
+      <div className="flex-1 space-y-1.5">
+        <h1 className="text-2xl font-bold">{RESUME_DATA.name}</h1>
+        <p className="max-w-md text-pretty font-mono text-sm text-muted-foreground">
+          {RESUME_DATA.about}
+        </p>
+        <p className="max-w-md items-center text-pretty font-mono text-xs text-muted-foreground">
+          <a
+            className="inline-flex gap-x-1.5 align-baseline leading-none hover:underline"
+            href={RESUME_DATA.locationLink}
+            target="_blank"
+          >
+            <GlobeIcon className="h-3 w-3" />
+            {RESUME_DATA.location}
+          </a>
+        </p>
+        <div className="flex gap-x-1 pt-1 font-mono text-sm text-muted-foreground print:hidden">
+          {RESUME_DATA.contact.email ? (
+            <Button className="h-8 w-8" variant="outline" size="icon" asChild>
+              <a href={`mailto:${RESUME_DATA.contact.email}`}>
+                <MailIcon className="h-4 w-4" />
+              </a>
+            </Button>
+          ) : null}
+          {RESUME_DATA.contact.tel ? (
+            <Button className="h-8 w-8" variant="outline" size="icon" asChild>
+              <a href={`tel:${RESUME_DATA.contact.tel}`}>
+                <PhoneIcon className="h-4 w-4" />
+              </a>
+            </Button>
+          ) : null}
+          {RESUME_DATA.contact.social.map((social) => (
+            <Button
+              key={social.name}
+              className="h-8 w-8"
+              variant="outline"
+              size="icon"
+              asChild
+            >
+              <a href={social.url}>
+                <social.icon className="h-4 w-4" />
+              </a>
+            </Button>
+          ))}
+        </div>
+        <div className="hidden flex-col gap-x-1 font-mono text-sm text-muted-foreground print:flex">
+          {RESUME_DATA.contact.email ? (
+            <a href={`mailto:${RESUME_DATA.contact.email}`}>
+              <span className="underline">{RESUME_DATA.contact.email}</span>
+            </a>
+          ) : null}
+          {RESUME_DATA.contact.tel ? (
+            <a href={`tel:${RESUME_DATA.contact.tel}`}>
+              <span className="underline">{RESUME_DATA.contact.tel}</span>
+            </a>
+          ) : null}
+        </div>
+      </div>
+
+      <Avatar className="h-28 w-28">
+        <AvatarImage alt={RESUME_DATA.name} src={RESUME_DATA.avatarUrl} />
+        <AvatarFallback>{RESUME_DATA.initials}</AvatarFallback>
+      </Avatar>
+    </div>
+  );
+};

--- a/src/components/sections/Projects.tsx
+++ b/src/components/sections/Projects.tsx
@@ -1,0 +1,24 @@
+import { RESUME_DATA } from "@/data/resume-data";
+import { ProjectCard } from "../project-card";
+import { Section } from "../ui/section";
+
+export const Projects = () => {
+  return (
+    <Section className="print-force-new-page scroll-mb-16">
+      <h2 className="text-xl font-bold">Projects</h2>
+      <div className="-mx-3 grid grid-cols-1 gap-3 print:grid-cols-3 print:gap-2 md:grid-cols-2 lg:grid-cols-3">
+        {RESUME_DATA.projects.map((project) => {
+          return (
+            <ProjectCard
+              key={project.title}
+              title={project.title}
+              description={project.description}
+              tags={project.techStack}
+              link={"link" in project ? project.link.href : undefined}
+            />
+          );
+        })}
+      </div>
+    </Section>
+  );
+};

--- a/src/components/sections/Skills.tsx
+++ b/src/components/sections/Skills.tsx
@@ -1,0 +1,16 @@
+import { RESUME_DATA } from "@/data/resume-data";
+import { Section } from "../ui/section";
+import { Badge } from "../ui/badge";
+
+export const Skills = () => {
+  return (
+    <Section>
+      <h2 className="text-xl font-bold">Skills</h2>
+      <div className="flex flex-wrap gap-1">
+        {RESUME_DATA.skills.map((skill) => {
+          return <Badge key={skill}>{skill}</Badge>;
+        })}
+      </div>
+    </Section>
+  );
+};

--- a/src/components/sections/Summary.tsx
+++ b/src/components/sections/Summary.tsx
@@ -1,0 +1,13 @@
+import { RESUME_DATA } from "@/data/resume-data";
+import { Section } from "../ui/section";
+
+export const Summary = () => {
+  return (
+    <Section>
+      <h2 className="text-xl font-bold">About</h2>
+      <p className="text-pretty font-mono text-sm text-muted-foreground">
+        {RESUME_DATA.summary}
+      </p>
+    </Section>
+  );
+};

--- a/src/components/sections/WorkExperience.tsx
+++ b/src/components/sections/WorkExperience.tsx
@@ -1,0 +1,47 @@
+import { RESUME_DATA } from "@/data/resume-data";
+import { Section } from "../ui/section";
+import { Card, CardContent, CardHeader } from "../ui/card";
+import { Badge } from "../ui/badge";
+
+export const WorkExperience = () => {
+  return (
+    <Section>
+      <h2 className="text-xl font-bold">Work Experience</h2>
+      {RESUME_DATA.work.map((work) => {
+        return (
+          <Card key={work.company}>
+            <CardHeader>
+              <div className="flex items-center justify-between gap-x-2 text-base">
+                <h3 className="inline-flex items-center justify-center gap-x-1 font-semibold leading-none">
+                  <a className="hover:underline" href={work.link}>
+                    {work.company}
+                  </a>
+
+                  <span className="inline-flex gap-x-1">
+                    {work.badges.map((badge) => (
+                      <Badge
+                        variant="secondary"
+                        className="align-middle text-xs"
+                        key={badge}
+                      >
+                        {badge}
+                      </Badge>
+                    ))}
+                  </span>
+                </h3>
+                <div className="text-sm tabular-nums text-gray-500">
+                  {work.start} - {work.end}
+                </div>
+              </div>
+
+              <h4 className="font-mono text-sm leading-none">{work.title}</h4>
+            </CardHeader>
+            <CardContent className="mt-2 text-xs">
+              {work.description}
+            </CardContent>
+          </Card>
+        );
+      })}
+    </Section>
+  );
+};


### PR DESCRIPTION
## ⚠️ Major Refactor ⚠️

### Moving Sections markup into individual components

This PR creates components for sections like personal info, about, projects etc

### Reason

The home page has a lot of markup, making it hard to navigate and read. Additional sections will make the readability even worse

### Changes

Just took the markup and pasted into a new component just for better readability and ability to add more sections without overcrowding the home page.

The components don't take props, they use the global `RESUME_DATA` object.