### PR TITLE
Display the correct button based on the user platform

### DIFF
--- a/src/components/command-menu.tsx
+++ b/src/components/command-menu.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/command";
 import { Button } from "./ui/button";
 import { CommandIcon } from "lucide-react";
+import { useOS } from "@/hooks/useOS";
 
 interface Props {
   links: { url: string; title: string }[];
@@ -20,6 +21,7 @@ interface Props {
 
 export const CommandMenu = ({ links }: Props) => {
   const [open, setOpen] = React.useState(false);
+  const os = useOS();
 
   React.useEffect(() => {
     const down = (e: KeyboardEvent) => {
@@ -38,7 +40,7 @@ export const CommandMenu = ({ links }: Props) => {
       <p className="fixed bottom-0 left-0 right-0 hidden border-t border-t-muted bg-white p-1 text-center text-sm text-muted-foreground print:hidden xl:block">
         Press{" "}
         <kbd className="pointer-events-none inline-flex h-5 select-none items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground opacity-100">
-          <span className="text-xs">⌘</span>J
+          <span className="text-xs">{os === "mac" ? "⌘" : "CTRL"}</span>+ J
         </kbd>{" "}
         to open the command menu
       </p>

--- a/src/hooks/useOS.ts
+++ b/src/hooks/useOS.ts
@@ -1,0 +1,16 @@
+import { useEffect, useState } from "react";
+
+export type OS = "mac" | "other";
+
+export const useOS = () => {
+  const [os, setOs] = useState<OS>("mac");
+  useEffect(() => {
+    setOs(
+      window.navigator.userAgent.toLowerCase().includes("mac")
+        ? "mac"
+        : "other",
+    );
+  }, []);
+
+  return os;
+};

--- a/src/hooks/useOS.ts
+++ b/src/hooks/useOS.ts
@@ -1,16 +1,17 @@
-import { useEffect, useState } from "react";
+import { useMemo } from "react";
 
-export type OS = "mac" | "other";
+export type OS = "mac" | "windows" | "linux" | "other";
 
-export const useOS = () => {
-  const [os, setOs] = useState<OS>("mac");
-  useEffect(() => {
-    setOs(
-      window.navigator.userAgent.toLowerCase().includes("mac")
-        ? "mac"
-        : "other",
-    );
-  }, []);
+export const useOS = (): OS => {
+  const getOperatingSystem = (): OS => {
+    const userAgent = window.navigator.userAgent.toLowerCase();
 
-  return os;
+    if (userAgent.includes("mac")) return "mac";
+    if (userAgent.includes("win")) return "windows";
+    if (userAgent.includes("linux")) return "linux";
+
+    return "other";
+  };
+
+  return useMemo(() => getOperatingSystem(), []);
 };


### PR DESCRIPTION
Displays `⌘` on Mac and `CTRL` for other platforms in the command palette.

## Preview
Windows
![image](https://github.com/BartoszJarocki/cv/assets/25529286/f98728cc-d0bb-43ac-b37e-6d6af3c76070)

Mac
![image](https://github.com/BartoszJarocki/cv/assets/25529286/6383f9c9-f89b-4807-a852-e6025b2fdb72)
