### PR TITLE
[FEAT]: Auto Get Github Projects

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_BASE_URL=http://localhost:3000

--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,7 @@
+GITHUB_API=https://api.github.com
+# Your GitHub username
+GITHUB_USERNAME=
+# Sorting criteria for GitHub repositories: created, updated (default), pushed, or full_name
+GITHUB_SORT=
+# Number of projects displayed per page (default is 12)
+GITHUB_PER_PAGE=

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ yarn-error.log*
 
 # local env files
 .env*.local
+.env
 
 # vercel
 .vercel

--- a/src/app/api/github/route.ts
+++ b/src/app/api/github/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  const GITHUB_API = process.env.GITHUB_API || "https://api.github.com";
+  const GITHUB_USERNAME = process.env.GITHUB_USERNAME || "";
+  const GITHUB_SORT = process.env.GITHUB_SORT || "updated";
+  const GITHUB_PER_PAGE = process.env.GITHUB_PER_PAGE || "12";
+
+  if (!GITHUB_USERNAME) {
+    return NextResponse.json(
+      { error: "GitHub username is not defined" },
+      { status: 500 },
+    );
+  }
+
+  try {
+    const res = await fetch(
+      `${GITHUB_API}/users/${GITHUB_USERNAME}/repos?sort=${GITHUB_SORT}&per_page=${GITHUB_PER_PAGE}`,
+    );
+
+    if (!res.ok) {
+      return NextResponse.json(
+        { error: "Failed to fetch data from GitHub" },
+        { status: res.status },
+      );
+    }
+
+    const data = await res.json();
+    return NextResponse.json(data);
+  } catch (error) {
+    return NextResponse.json(
+      { error: "Failed to fetch data" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/components/Projects.tsx
+++ b/src/app/components/Projects.tsx
@@ -1,10 +1,12 @@
+import { getGithubProjectData } from "@/lib/get-project-data";
+import { use } from "react";
 import { Badge } from "../../components/ui/badge";
 import {
   Card,
+  CardContent,
+  CardDescription,
   CardHeader,
   CardTitle,
-  CardDescription,
-  CardContent,
 } from "../../components/ui/card";
 import { Section } from "../../components/ui/section";
 import { RESUME_DATA } from "../../data/resume-data";
@@ -30,15 +32,18 @@ function ProjectLink({ title, link }: ProjectLinkProps) {
         href={link}
         target="_blank"
         rel="noopener noreferrer"
-        className="inline-flex items-center gap-1 hover:underline"
+        className="inline-flex items-center justify-between gap-1 hover:underline"
         aria-label={`${title} project (opens in new tab)`}
       >
-        {title}
-        <span
-          className="size-1 rounded-full bg-green-500"
-          aria-label="Active project indicator"
-        />
+        <>
+          {title}
+          <span
+            className="size-1 rounded-full bg-green-500"
+            aria-label="Active project indicator"
+          />
+        </>
       </a>
+
       <div
         className="hidden font-mono text-xs underline print:visible"
         aria-hidden="true"
@@ -122,6 +127,8 @@ interface ProjectsProps {
  * Section component displaying all side projects
  */
 export function Projects({ projects }: ProjectsProps) {
+  const githubProjects = use(getGithubProjectData());
+
   return (
     <Section className="print-force-new-page scroll-mb-16 print:space-y-4 print:pt-12">
       <h2 className="text-xl font-bold" id="side-projects">
@@ -132,19 +139,27 @@ export function Projects({ projects }: ProjectsProps) {
         role="feed"
         aria-labelledby="side-projects"
       >
-        {projects.map((project) => (
-          <article
-            key={project.title}
-            className="h-full" // Added h-full here
-          >
-            <ProjectCard
-              title={project.title}
-              description={project.description}
-              tags={project.techStack}
-              link={"link" in project ? project.link.href : undefined}
-            />
-          </article>
-        ))}
+        {!!githubProjects
+          ? githubProjects.map((project) => (
+              <article key={project.id} className="h-full">
+                <ProjectCard
+                  title={project.name}
+                  description={project.description || ""}
+                  tags={project.language ? [project.language] : []}
+                  link={project.html_url}
+                />
+              </article>
+            ))
+          : projects.map((project) => (
+              <article key={project.title} className="h-full">
+                <ProjectCard
+                  title={project.title}
+                  description={project.description}
+                  tags={project.techStack}
+                  link={"link" in project ? project.link.href : undefined}
+                />
+              </article>
+            ))}
       </div>
     </Section>
   );

--- a/src/lib/get-project-data.ts
+++ b/src/lib/get-project-data.ts
@@ -1,0 +1,26 @@
+export interface Repo {
+  id: number;
+  name: string;
+  html_url: string;
+  description?: string;
+  stargazers_count: number;
+  language: string;
+}
+
+export async function getGithubProjectData(): Promise<Repo[] | null> {
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL ?? "http://localhost:3000";
+
+  const res = await fetch(`${baseUrl}/api/github`);
+
+  const data = await res.json();
+
+  if (data.error) {
+    console.warn({
+      message: "Failed to fetch GitHub repositories",
+      error: data.error,
+      status: res.status,
+    });
+    return null;
+  }
+  return data;
+}


### PR DESCRIPTION
### What was made: 

- Added `.env.local.example` and `.env.example` files to dynamically changes by passing the values within the comments.
- Added an API call using `Next/Server` to the github endpoint and dealed with some exceptions.
- Created an function retrieving the data from the API and consumed in the `Projects.tsx` component
- Made conditions to the data appeared into SideProjects where:
  - If passed an valid username for `GITHUB_USERNAME` at `.env.local` file it will retrieve the repos from the user and show in screen 
  - Else, it will render the static side projects passed in the `data/resume-data.tsx`
  
 
### How to test
  
  - First copy the `.env.example` and `.env.local.example` files to your workspace usign: 
  ```bash
    cp .env.example .env
    cp .env.example.local .env.local
  ```
  - Then at `.env.local` fullfill the `GITHUB_USERNAME` with your username profile.
    - There are also query params to be passed, but if not, it will use the default values at the comment
    ```
      GITHUB_API=https://api.github.com
      # Your GitHub username
      GITHUB_USERNAME=JonGlazkov
      # Sorting criteria for GitHub repositories: created, updated (default), pushed, or full_name
      GITHUB_SORT=
      # Number of projects displayed per page (default is 12)
      GITHUB_PER_PAGE=
    ```
    
   
  This PR was created to resolve the issue #69 